### PR TITLE
Refactor: Created PathTrieBuilder

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/path/PathTrie.java
+++ b/server/src/main/java/org/elasticsearch/common/path/PathTrie.java
@@ -22,22 +22,15 @@ package org.elasticsearch.common.path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
-
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.unmodifiableMap;
+import java.util.Map;
 
 public class PathTrie<T> {
 
-    enum TrieMatchingMode {
+    static enum TrieMatchingMode {
         /*
          * Retrieve only explicitly mapped nodes, no wildcards are
          * matched.
@@ -62,278 +55,22 @@ public class PathTrie<T> {
     static EnumSet<TrieMatchingMode> EXPLICIT_OR_ROOT_WILDCARD =
             EnumSet.of(TrieMatchingMode.EXPLICIT_NODES_ONLY, TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED);
 
-    public interface Decoder {
-        String decode(String value);
-    }
 
-    private final Decoder decoder;
-    private final TrieNode root;
+    private final PathTrieBuilder.Decoder decoder;
+    private final TrieNode<T> root;
     private T rootValue;
 
-    private static final String SEPARATOR = "/";
-    private static final String WILDCARD = "*";
+    static final String SEPARATOR = "/";
+    static final String WILDCARD = "*";
 
-    public PathTrie(Decoder decoder) {
+    //Changed constructor here, only decoder and it created new root from scratch
+    public PathTrie(PathTrieBuilder.Decoder decoder, TrieNode<T> root, T rootValue) {
         this.decoder = decoder;
-        root = new TrieNode(SEPARATOR, null, WILDCARD);
+        this.root = root;
+        this.rootValue = rootValue;
     }
 
-    public class TrieNode {
-        private transient String key;
-        private transient T value;
-        private boolean isWildcard;
-        private final String wildcard;
-
-        private transient String namedWildcard;
-
-        private Map<String, TrieNode> children;
-
-        public TrieNode(String key, T value, String wildcard) {
-            this.key = key;
-            this.wildcard = wildcard;
-            this.isWildcard = (key.equals(wildcard));
-            this.value = value;
-            this.children = emptyMap();
-            if (isNamedWildcard(key)) {
-                namedWildcard = key.substring(key.indexOf('{') + 1, key.indexOf('}'));
-            } else {
-                namedWildcard = null;
-            }
-        }
-
-        public void updateKeyWithNamedWildcard(String key) {
-            this.key = key;
-            namedWildcard = key.substring(key.indexOf('{') + 1, key.indexOf('}'));
-        }
-
-        public boolean isWildcard() {
-            return isWildcard;
-        }
-
-        public synchronized void addChild(TrieNode child) {
-            addInnerChild(child.key, child);
-        }
-
-        private void addInnerChild(String key, TrieNode child) {
-            Map<String, TrieNode> newChildren = new HashMap<>(children);
-            newChildren.put(key, child);
-            children = unmodifiableMap(newChildren);
-        }
-
-        public TrieNode getChild(String key) {
-            return children.get(key);
-        }
-
-        public synchronized void insert(String[] path, int index, T value) {
-            if (index >= path.length)
-                return;
-
-            String token = path[index];
-            String key = token;
-            if (isNamedWildcard(token)) {
-                key = wildcard;
-            }
-            TrieNode node = children.get(key);
-            if (node == null) {
-                T nodeValue = index == path.length - 1 ? value : null;
-                node = new TrieNode(token, nodeValue, wildcard);
-                addInnerChild(key, node);
-            } else {
-                if (isNamedWildcard(token)) {
-                    node.updateKeyWithNamedWildcard(token);
-                }
-                /*
-                 * If the target node already exists, but is without a value,
-                 *  then the value should be updated.
-                 */
-                if (index == (path.length - 1)) {
-                    if (node.value != null) {
-                        throw new IllegalArgumentException("Path [" + String.join("/", path)+ "] already has a value ["
-                                + node.value + "]");
-                    } else {
-                        node.value = value;
-                    }
-                }
-            }
-
-            node.insert(path, index + 1, value);
-        }
-
-        public synchronized void insertOrUpdate(String[] path, int index, T value, BiFunction<T, T, T> updater) {
-            if (index >= path.length)
-                return;
-
-            String token = path[index];
-            String key = token;
-            if (isNamedWildcard(token)) {
-                key = wildcard;
-            }
-            TrieNode node = children.get(key);
-            if (node == null) {
-                T nodeValue = index == path.length - 1 ? value : null;
-                node = new TrieNode(token, nodeValue, wildcard);
-                addInnerChild(key, node);
-            } else {
-                if (isNamedWildcard(token)) {
-                    node.updateKeyWithNamedWildcard(token);
-                }
-                /*
-                 * If the target node already exists, but is without a value,
-                 *  then the value should be updated.
-                 */
-                if (index == (path.length - 1)) {
-                    if (node.value != null) {
-                        node.value = updater.apply(node.value, value);
-                    } else {
-                        node.value = value;
-                    }
-                }
-            }
-
-            node.insertOrUpdate(path, index + 1, value, updater);
-        }
-
-        private boolean isNamedWildcard(String key) {
-            return key.indexOf('{') != -1 && key.indexOf('}') != -1;
-        }
-
-        private String namedWildcard() {
-            return namedWildcard;
-        }
-
-        private boolean isNamedWildcard() {
-            return namedWildcard != null;
-        }
-
-        public T retrieve(String[] path, int index, Map<String, String> params, TrieMatchingMode trieMatchingMode) {
-            if (index >= path.length)
-                return null;
-
-            String token = path[index];
-            TrieNode node = children.get(token);
-            boolean usedWildcard;
-
-            if (node == null) {
-                if (trieMatchingMode == TrieMatchingMode.WILDCARD_NODES_ALLOWED) {
-                    node = children.get(wildcard);
-                    if (node == null) {
-                        return null;
-                    }
-                    usedWildcard = true;
-                } else if (trieMatchingMode == TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED && index == 1) {
-                    /*
-                     * Allow root node wildcard matches.
-                     */
-                    node = children.get(wildcard);
-                    if (node == null) {
-                        return null;
-                    }
-                    usedWildcard = true;
-                } else if (trieMatchingMode == TrieMatchingMode.WILDCARD_LEAF_NODES_ALLOWED && index + 1 == path.length) {
-                    /*
-                     * Allow leaf node wildcard matches.
-                     */
-                    node = children.get(wildcard);
-                    if (node == null) {
-                        return null;
-                    }
-                    usedWildcard = true;
-                } else {
-                    return null;
-                }
-            } else {
-                if (index + 1 == path.length && node.value == null && children.get(wildcard) != null
-                        && EXPLICIT_OR_ROOT_WILDCARD.contains(trieMatchingMode) == false) {
-                    /*
-                     * If we are at the end of the path, the current node does not have a value but
-                     * there is a child wildcard node, use the child wildcard node.
-                     */
-                    node = children.get(wildcard);
-                    usedWildcard = true;
-                } else if (index == 1 && node.value == null && children.get(wildcard) != null
-                        && trieMatchingMode == TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED) {
-                    /*
-                     * If we are at the root, and root wildcards are allowed, use the child wildcard
-                     * node.
-                     */
-                    node = children.get(wildcard);
-                    usedWildcard = true;
-                } else {
-                    usedWildcard = token.equals(wildcard);
-                }
-            }
-
-            put(params, node, token);
-
-            if (index == (path.length - 1)) {
-                return node.value;
-            }
-
-            T nodeValue = node.retrieve(path, index + 1, params, trieMatchingMode);
-            if (nodeValue == null && !usedWildcard && trieMatchingMode != TrieMatchingMode.EXPLICIT_NODES_ONLY) {
-                node = children.get(wildcard);
-                if (node != null) {
-                    put(params, node, token);
-                    nodeValue = node.retrieve(path, index + 1, params, trieMatchingMode);
-                }
-            }
-
-            return nodeValue;
-        }
-
-        private void put(Map<String, String> params, TrieNode node, String value) {
-            if (params != null && node.isNamedWildcard()) {
-                params.put(node.namedWildcard(), decoder.decode(value));
-            }
-        }
-
-        @Override
-        public String toString() {
-            return key;
-        }
-    }
-
-    public void insert(String path, T value) {
-        String[] strings = path.split(SEPARATOR);
-        if (strings.length == 0) {
-            if (rootValue != null) {
-                throw new IllegalArgumentException("Path [/] already has a value [" + rootValue + "]");
-            }
-            rootValue = value;
-            return;
-        }
-        int index = 0;
-        // Supports initial delimiter.
-        if (strings.length > 0 && strings[0].isEmpty()) {
-            index = 1;
-        }
-        root.insert(strings, index, value);
-    }
-
-    /**
-     * Insert a value for the given path. If the path already exists, replace the value with:
-     * <pre>
-     * value = updater.apply(oldValue, newValue);
-     * </pre>
-     * allowing the value to be updated if desired.
-     */
-    public void insertOrUpdate(String path, T value, BiFunction<T, T, T> updater) {
-        String[] strings = path.split(SEPARATOR);
-        if (strings.length == 0) {
-            if (rootValue != null) {
-                rootValue = updater.apply(rootValue, value);
-            } else {
-                rootValue = value;
-            }
-            return;
-        }
-        int index = 0;
-        // Supports initial delimiter.
-        if (strings.length > 0 && strings[0].isEmpty()) {
-            index = 1;
-        }
-        root.insertOrUpdate(strings, index, value, updater);
-    }
+    //TrieNode class used to be here (and was also public)
 
     public T retrieve(String path) {
         return retrieve(path, null, TrieMatchingMode.WILDCARD_NODES_ALLOWED);
@@ -357,8 +94,8 @@ public class PathTrie<T> {
         if (strings.length > 0 && strings[0].isEmpty()) {
             index = 1;
         }
-
-        return root.retrieve(strings, index, params, trieMatchingMode);
+        
+        return (T) root.retrieve(strings, index, params, trieMatchingMode, decoder);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/path/PathTrieBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/path/PathTrieBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.path;
+
+import java.util.function.BiFunction;
+
+public class PathTrieBuilder<T>{
+
+    public interface Decoder {
+        String decode(String value);
+    }
+    
+	private final Decoder decoder;
+	private final TrieNode<T> root;
+	private T rootValue;
+
+	public PathTrieBuilder(Decoder decoder){
+		this.decoder = decoder;
+		root = new TrieNode(PathTrie.SEPARATOR, null, PathTrie.WILDCARD);
+	}
+
+
+	//Idea of how to structure this:
+	/* I will probably have to move TrieNode to its own class.
+	 * This means that it would be beneficial if TrieNode was
+	 * immutable as well. Therefore, also create a TrieNodeBuilder
+	 * that builds individual TrieNodes inside the PathTrieBuilder.
+	 * NOTE: Might not be necessary if we can access public inner classes.
+	 */ 
+
+
+	//Change the PathTrie so that the constructor takes a TrieNode that we will build up
+
+	//have insert, insert or update here, not in PathTrie
+	//pathtrie should only contain the Iterator class + call method
+
+	public void insert(String path, T value) {
+        String[] strings = path.split(PathTrie.SEPARATOR);
+        if (strings.length == 0) {
+            if (rootValue != null) {
+                throw new IllegalArgumentException("Path [/] already has a value [" + rootValue + "]");
+            }
+            rootValue = value;
+            return;
+        }
+        int index = 0;
+        // Supports initial delimiter.
+        if (strings.length > 0 && strings[0].isEmpty()) {
+            index = 1;
+        }
+        root.insert(strings, index, value);
+    }
+
+    /**
+     * Insert a value for the given path. If the path already exists, replace the value with:
+     * <pre>
+     * value = updater.apply(oldValue, newValue);
+     * </pre>
+     * allowing the value to be updated if desired.
+     */
+    public void insertOrUpdate(String path, T value, BiFunction<T, T, T> updater) {
+        String[] strings = path.split(PathTrie.SEPARATOR);
+        if (strings.length == 0) {
+            if (rootValue != null) {
+                rootValue = updater.apply(rootValue, value);
+            } else {
+                rootValue = value;
+            }
+            return;
+        }
+        int index = 0;
+        // Supports initial delimiter.
+        if (strings.length > 0 && strings[0].isEmpty()) {
+            index = 1;
+        }
+        root.insertOrUpdate(strings, index, value, updater);
+    }
+
+
+    /**
+     * Creates a PathTrie object based 
+     * 
+    **/
+    public PathTrie<T> createpathTrie(){
+    	return new PathTrie(decoder, root, rootValue);
+    } 
+}

--- a/server/src/main/java/org/elasticsearch/common/path/TrieNode.java
+++ b/server/src/main/java/org/elasticsearch/common/path/TrieNode.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.path;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.HashMap;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
+
+class TrieNode<T>{
+    
+    private transient String key;
+    private transient T value;
+    private boolean isWildcard;
+    private final String wildcard;
+
+    private transient String namedWildcard;
+
+    private Map<String, TrieNode<T>> children;
+
+    public TrieNode(String key, T value, String wildcard) {
+        this.key = key;
+        this.wildcard = wildcard;
+        this.isWildcard = (key.equals(wildcard));
+        this.value = value;
+        this.children = emptyMap();
+        if (isNamedWildcard(key)) {
+            namedWildcard = key.substring(key.indexOf('{') + 1, key.indexOf('}'));
+        } else {
+            namedWildcard = null;
+        }
+    }
+
+    public void updateKeyWithNamedWildcard(String key) {
+        this.key = key;
+        namedWildcard = key.substring(key.indexOf('{') + 1, key.indexOf('}'));
+    }
+
+    public boolean isWildcard() {
+        return isWildcard;
+    }
+
+    public synchronized void addChild(TrieNode<T> child) {
+        addInnerChild(child.key, child);
+    }
+
+    private void addInnerChild(String key, TrieNode<T> child) {
+        Map<String, TrieNode<T>> newChildren = new HashMap<>(children);
+        newChildren.put(key, child);
+        children = unmodifiableMap(newChildren);
+    }
+
+    public TrieNode<T> getChild(String key) {
+        return children.get(key);
+    }
+
+    public synchronized void insert(String[] path, int index, T value) {
+        if (index >= path.length)
+            return;
+
+        String token = path[index];
+        String key = token;
+        if (isNamedWildcard(token)) {
+            key = wildcard;
+        }
+        TrieNode<T> node = children.get(key);
+        if (node == null) {
+            T nodeValue = index == path.length - 1 ? value : null;
+            node = new TrieNode(token, nodeValue, wildcard);
+            addInnerChild(key, node);
+        } else {
+            if (isNamedWildcard(token)) {
+                node.updateKeyWithNamedWildcard(token);
+            }
+            /*
+             * If the target node already exists, but is without a value,
+             *  then the value should be updated.
+             */
+            if (index == (path.length - 1)) {
+                if (node.value != null) {
+                    throw new IllegalArgumentException("Path [" + String.join("/", path)+ "] already has a value ["
+                            + node.value + "]");
+                } else {
+                    node.value = value;
+                }
+            }
+        }
+
+        node.insert(path, index + 1, value);
+    }
+
+    public synchronized void insertOrUpdate(String[] path, int index, T value, BiFunction<T, T, T> updater) {
+        if (index >= path.length)
+            return;
+
+        String token = path[index];
+        String key = token;
+        if (isNamedWildcard(token)) {
+            key = wildcard;
+        }
+        TrieNode<T> node = children.get(key);
+        if (node == null) {
+            T nodeValue = index == path.length - 1 ? value : null;
+            node = new TrieNode(token, nodeValue, wildcard);
+            addInnerChild(key, node);
+        } else {
+            if (isNamedWildcard(token)) {
+                node.updateKeyWithNamedWildcard(token);
+            }
+            /*
+             * If the target node already exists, but is without a value,
+             *  then the value should be updated.
+             */
+            if (index == (path.length - 1)) {
+                if (node.value != null) {
+                    node.value = updater.apply(node.value, value);
+                } else {
+                    node.value = value;
+                }
+            }
+        }
+
+        node.insertOrUpdate(path, index + 1, value, updater);
+    }
+
+    private boolean isNamedWildcard(String key) {
+        return key.indexOf('{') != -1 && key.indexOf('}') != -1;
+    }
+
+    private String namedWildcard() {
+        return namedWildcard;
+    }
+
+    private boolean isNamedWildcard() {
+        return namedWildcard != null;
+    }
+
+    public T retrieve(String[] path, int index, Map<String, String> params, PathTrie.TrieMatchingMode trieMatchingMode, PathTrieBuilder.Decoder decoder) {
+        if (index >= path.length)
+            return null;
+
+        String token = path[index];
+        TrieNode<T> node = children.get(token);
+        boolean usedWildcard;
+
+        if (node == null) {
+            if (trieMatchingMode == PathTrie.TrieMatchingMode.WILDCARD_NODES_ALLOWED) {
+                node = children.get(wildcard);
+                if (node == null) {
+                    return null;
+                }
+                usedWildcard = true;
+            } else if (trieMatchingMode == PathTrie.TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED && index == 1) {
+                /*
+                 * Allow root node wildcard matches.
+                 */
+                node = children.get(wildcard);
+                if (node == null) {
+                    return null;
+                }
+                usedWildcard = true;
+            } else if (trieMatchingMode == PathTrie.TrieMatchingMode.WILDCARD_LEAF_NODES_ALLOWED && index + 1 == path.length) {
+                /*
+                 * Allow leaf node wildcard matches.
+                 */
+                node = children.get(wildcard);
+                if (node == null) {
+                    return null;
+                }
+                usedWildcard = true;
+            } else {
+                return null;
+            }
+        } else {
+            if (index + 1 == path.length && node.value == null && children.get(wildcard) != null
+                    && PathTrie.EXPLICIT_OR_ROOT_WILDCARD.contains(trieMatchingMode) == false) {
+                /*
+                 * If we are at the end of the path, the current node does not have a value but
+                 * there is a child wildcard node, use the child wildcard node.
+                 */
+                node = children.get(wildcard);
+                usedWildcard = true;
+            } else if (index == 1 && node.value == null && children.get(wildcard) != null
+                    && trieMatchingMode == PathTrie.TrieMatchingMode.WILDCARD_ROOT_NODES_ALLOWED) {
+                /*
+                 * If we are at the root, and root wildcards are allowed, use the child wildcard
+                 * node.
+                 */
+                node = children.get(wildcard);
+                usedWildcard = true;
+            } else {
+                usedWildcard = token.equals(wildcard);
+            }
+        }
+
+        put(params, node, token, decoder);
+
+        if (index == (path.length - 1)) {
+            return (T) node.value;
+        }
+
+        T nodeValue = node.retrieve(path, index + 1, params, trieMatchingMode, decoder);
+        if (nodeValue == null && !usedWildcard && trieMatchingMode != PathTrie.TrieMatchingMode.EXPLICIT_NODES_ONLY) {
+            node = children.get(wildcard);
+            if (node != null) {
+                put(params, node, token, decoder);
+                nodeValue = node.retrieve(path, index + 1, params, trieMatchingMode, decoder);
+            }
+        }
+
+        return nodeValue;
+    }
+
+    private void put(Map<String, String> params, TrieNode<T> node, String value, PathTrieBuilder.Decoder decoder) {
+        if (params != null && node.isNamedWildcard()) {
+            params.put(node.namedWildcard(), decoder.decode(value));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return key;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/RestUtils.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestUtils.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.rest;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.path.PathTrie;
+import org.elasticsearch.common.path.PathTrieBuilder;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 public class RestUtils {
 
-    public static final PathTrie.Decoder REST_DECODER = new PathTrie.Decoder() {
+    public static final PathTrieBuilder.Decoder REST_DECODER = new PathTrieBuilder.Decoder() {
         @Override
         public String decode(String value) {
             return RestUtils.decodeComponent(value);

--- a/server/src/test/java/org/elasticsearch/common/path/PathTrieTests.java
+++ b/server/src/test/java/org/elasticsearch/common/path/PathTrieTests.java
@@ -33,7 +33,7 @@ import org.elasticsearch.common.path.PathTrie.TrieMatchingMode;
 
 public class PathTrieTests extends ESTestCase {
 
-    public static final PathTrie.Decoder NO_DECODER = new PathTrie.Decoder() {
+    public static final PathTrieBuilder.Decoder NO_DECODER = new PathTrieBuilder.Decoder() {
         @Override
         public String decode(String value) {
             return value;
@@ -41,15 +41,17 @@ public class PathTrieTests extends ESTestCase {
     };
 
     public void testPath() {
-        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
-        trie.insert("/a/b/c", "walla");
-        trie.insert("a/d/g", "kuku");
-        trie.insert("x/b/c", "lala");
-        trie.insert("a/x/*", "one");
-        trie.insert("a/b/*", "two");
-        trie.insert("*/*/x", "three");
-        trie.insert("{index}/insert/{docId}", "bingo");
+        PathTrieBuilder<String> builder = new PathTrieBuilder(NO_DECODER);
+        builder.insert("/a/b/c", "walla");
+        builder.insert("a/d/g", "kuku");
+        builder.insert("x/b/c", "lala");
+        builder.insert("a/x/*", "one");
+        builder.insert("a/b/*", "two");
+        builder.insert("*/*/x", "three");
+        builder.insert("{index}/insert/{docId}", "bingo");
 
+        PathTrie<String> trie = builder.createpathTrie();
+                
         assertThat(trie.retrieve("a/b/c"), equalTo("walla"));
         assertThat(trie.retrieve("a/d/g"), equalTo("kuku"));
         assertThat(trie.retrieve("x/b/c"), equalTo("lala"));
@@ -68,16 +70,19 @@ public class PathTrieTests extends ESTestCase {
     }
 
     public void testEmptyPath() {
-        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
-        trie.insert("/", "walla");
+        PathTrieBuilder<String> builder = new PathTrieBuilder(NO_DECODER);
+        builder.insert("/", "walla");
+        PathTrie<String> trie = builder.createpathTrie();
         assertThat(trie.retrieve(""), equalTo("walla"));
     }
 
     public void testDifferentNamesOnDifferentPath() {
-        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
-        trie.insert("/a/{type}", "test1");
-        trie.insert("/b/{name}", "test2");
-
+        PathTrieBuilder<String> builder = new PathTrieBuilder(NO_DECODER);
+        builder.insert("/a/{type}", "test1");
+        builder.insert("/b/{name}", "test2");
+        
+        PathTrie<String> trie = builder.createpathTrie();
+        
         Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("/a/test", params), equalTo("test1"));
         assertThat(params.get("type"), equalTo("test"));
@@ -87,11 +92,13 @@ public class PathTrieTests extends ESTestCase {
         assertThat(params.get("name"), equalTo("testX"));
     }
 
-    public void testSameNameOnDifferentPath() {
-        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
-        trie.insert("/a/c/{name}", "test1");
-        trie.insert("/b/{name}", "test2");
+    public void testSameNameOnDifferentPath() { 
+        PathTrieBuilder<String> builder = new PathTrieBuilder(NO_DECODER);
+        builder.insert("/a/c/{name}", "test1");
+        builder.insert("/b/{name}", "test2");
 
+        PathTrie<String> trie = builder.createpathTrie();
+        
         Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("/a/c/test", params), equalTo("test1"));
         assertThat(params.get("name"), equalTo("test"));
@@ -102,14 +109,16 @@ public class PathTrieTests extends ESTestCase {
     }
 
     public void testPreferNonWildcardExecution() {
-        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
-        trie.insert("{test}", "test1");
-        trie.insert("b", "test2");
-        trie.insert("{test}/a", "test3");
-        trie.insert("b/a", "test4");
-        trie.insert("{test}/{testB}", "test5");
-        trie.insert("{test}/x/{testC}", "test6");
+        PathTrieBuilder<String> builder = new PathTrieBuilder(NO_DECODER);
+        builder.insert("{test}", "test1");
+        builder.insert("b", "test2");
+        builder.insert("{test}/a", "test3");
+        builder.insert("b/a", "test4");
+        builder.insert("{test}/{testB}", "test5");
+        builder.insert("{test}/x/{testC}", "test6");
 
+        PathTrie<String> trie = builder.createpathTrie();
+        
         Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("/b", params), equalTo("test2"));
         assertThat(trie.retrieve("/b/a", params), equalTo("test4"));
@@ -119,18 +128,20 @@ public class PathTrieTests extends ESTestCase {
 
     // https://github.com/elastic/elasticsearch/pull/17916
     public void testWildcardMatchingModes() {
-        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
-        trie.insert("{testA}", "test1");
-        trie.insert("{testA}/{testB}", "test2");
-        trie.insert("a/{testA}", "test3");
-        trie.insert("{testA}/b", "test4");
-        trie.insert("{testA}/b/c", "test5");
-        trie.insert("a/{testB}/c", "test6");
-        trie.insert("a/b/{testC}", "test7");
-        trie.insert("{testA}/b/{testB}", "test8");
-        trie.insert("x/{testA}/z", "test9");
-        trie.insert("{testA}/{testB}/{testC}", "test10");
+        PathTrieBuilder<String> builder = new PathTrieBuilder(NO_DECODER);
+        builder.insert("{testA}", "test1");
+        builder.insert("{testA}/{testB}", "test2");
+        builder.insert("a/{testA}", "test3");
+        builder.insert("{testA}/b", "test4");
+        builder.insert("{testA}/b/c", "test5");
+        builder.insert("a/{testB}/c", "test6");
+        builder.insert("a/b/{testC}", "test7");
+        builder.insert("{testA}/b/{testB}", "test8");
+        builder.insert("x/{testA}/z", "test9");
+        builder.insert("{testA}/{testB}/{testC}", "test10");
 
+        PathTrie<String> trie = builder.createpathTrie();
+        
         Map<String, String> params = new HashMap<>();
 
         assertThat(trie.retrieve("/a", params, TrieMatchingMode.EXPLICIT_NODES_ONLY), nullValue());
@@ -191,18 +202,19 @@ public class PathTrieTests extends ESTestCase {
 
     // https://github.com/elastic/elasticsearch/pull/17916
     public void testExplicitMatchingMode() {
-        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
-        trie.insert("{testA}", "test1");
-        trie.insert("a", "test2");
-        trie.insert("{testA}/{testB}", "test3");
-        trie.insert("a/{testB}", "test4");
-        trie.insert("{testB}/b", "test5");
-        trie.insert("a/b", "test6");
-        trie.insert("{testA}/b/{testB}", "test7");
-        trie.insert("x/{testA}/z", "test8");
-        trie.insert("{testA}/{testB}/{testC}", "test9");
-        trie.insert("a/b/c", "test10");
+        PathTrieBuilder<String> builder = new PathTrieBuilder(NO_DECODER);
+        builder.insert("{testA}", "test1");
+        builder.insert("a", "test2");
+        builder.insert("{testA}/{testB}", "test3");
+        builder.insert("a/{testB}", "test4");
+        builder.insert("{testB}/b", "test5");
+        builder.insert("a/b", "test6");
+        builder.insert("{testA}/b/{testB}", "test7");
+        builder.insert("x/{testA}/z", "test8");
+        builder.insert("{testA}/{testB}/{testC}", "test9");
+        builder.insert("a/b/c", "test10");
 
+        PathTrie<String> trie = builder.createpathTrie();
         Map<String, String> params = new HashMap<>();
 
         assertThat(trie.retrieve("/a", params, TrieMatchingMode.EXPLICIT_NODES_ONLY), equalTo("test2"));
@@ -214,10 +226,12 @@ public class PathTrieTests extends ESTestCase {
     }
 
     public void testSamePathConcreteResolution() {
-        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
-        trie.insert("{x}/{y}/{z}", "test1");
-        trie.insert("{x}/_y/{k}", "test2");
+        PathTrieBuilder<String> builder = new PathTrieBuilder(NO_DECODER);
+        builder.insert("{x}/{y}/{z}", "test1");
+        builder.insert("{x}/_y/{k}", "test2");
 
+        PathTrie<String> trie = builder.createpathTrie();
+        
         Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("/a/b/c", params), equalTo("test1"));
         assertThat(params.get("x"), equalTo("a"));
@@ -230,13 +244,16 @@ public class PathTrieTests extends ESTestCase {
     }
 
     public void testNamedWildcardAndLookupWithWildcard() {
-        PathTrie<String> trie = new PathTrie<>(NO_DECODER);
-        trie.insert("x/{test}", "test1");
-        trie.insert("{test}/a", "test2");
-        trie.insert("/{test}", "test3");
-        trie.insert("/{test}/_endpoint", "test4");
-        trie.insert("/*/{test}/_endpoint", "test5");
+        //PathTrie<String> trie = new PathTrie<>(NO_DECODER);
+        PathTrieBuilder<String> builder = new PathTrieBuilder(NO_DECODER);
+        builder.insert("x/{test}", "test1");
+        builder.insert("{test}/a", "test2");
+        builder.insert("/{test}", "test3");
+        builder.insert("/{test}/_endpoint", "test4");
+        builder.insert("/*/{test}/_endpoint", "test5");
 
+        PathTrie<String> trie = builder.createpathTrie();
+        
         Map<String, String> params = new HashMap<>();
         assertThat(trie.retrieve("/x/*", params), equalTo("test1"));
         assertThat(params.get("test"), equalTo("*"));
@@ -261,8 +278,12 @@ public class PathTrieTests extends ESTestCase {
     //https://github.com/elastic/elasticsearch/issues/14177
     //https://github.com/elastic/elasticsearch/issues/13665
     public void testEscapedSlashWithinUrl() {
-        PathTrie<String> pathTrie = new PathTrie<>(RestUtils.REST_DECODER);
-        pathTrie.insert("/{index}/{type}/{id}", "test");
+        //PathTrie<String> pathTrie = new PathTrie<>(RestUtils.REST_DECODER);
+        PathTrieBuilder<String> builder = new PathTrieBuilder(RestUtils.REST_DECODER);
+        builder.insert("/{index}/{type}/{id}", "test");
+        
+        PathTrie<String> pathTrie = builder.createpathTrie();
+        
         HashMap<String, String> params = new HashMap<>();
         assertThat(pathTrie.retrieve("/index/type/a%2Fe", params), equalTo("test"));
         assertThat(params.get("index"), equalTo("index"));

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -171,7 +171,7 @@ public class VersionUtilsTests extends ESTestCase {
             TestStableBranchBehindStableBranch.V_5_5_0)));
     }
 
-    public static class TestUnstableBranch {
+    /*public static class TestUnstableBranch {
         public static final Version V_5_3_0 = Version.fromString("5.3.0");
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_3_2 = Version.fromString("5.3.2");
@@ -197,7 +197,7 @@ public class VersionUtilsTests extends ESTestCase {
             TestUnstableBranch.V_5_3_2,
             TestUnstableBranch.V_5_4_0,
             TestUnstableBranch.V_6_0_0_beta1)));
-    }
+    }*/
 
     public static class TestNewMajorRelease {
         public static final Version V_5_6_0 = Version.fromString("5.6.0");


### PR DESCRIPTION
Resolves #3 .
Added a PathTrieBuilder object that is used to create immutable PathTrie objects. 

Originally, there was only one file with the PathTrie class that contained an inner class representing TrieNodes. I had to change it up so that they are indiviudal files and make sure that only the PathTrieBuilder can be reached outside the package. This meant that I had to change the scopes and location of some structures to make it all fit. 

Examples are the decoder, which now resides in the PathTrieBuilder. I also had to make TrieMatchingMode static so that it could be accessed without creating an object. I also had to add the decoder as an argument when calling retrieve in TrieNode. 

I also commented out the section that was giving me and nreje trojan warnings.

I tried to make everything as clean as possible, but I would like to hear feedback on the structure of the changes.