### PR TITLE
refactor: Storing values in Lucene compatible style

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/path/FSTRepresentation.java
+++ b/server/src/main/java/org/elasticsearch/common/path/FSTRepresentation.java
@@ -1,0 +1,62 @@
+package org.elasticsearch.common.path;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+
+public class FSTRepresentation<T> {
+
+	/**
+	 * Convert the value to a byte-array for storing
+	 * @param value The value to be converted to bytes
+	 * @return Returns the bytes of the given value, or null if something fails
+	 */
+	public byte[] toBytes(T value) {
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		ObjectOutput out = null;
+		byte[] ret = null;
+		try {
+			out = new ObjectOutputStream(bos);
+			out.writeObject(value);
+			out.flush();
+			ret = bos.toByteArray();
+		} catch (IOException e) {
+			try { bos.close(); } catch (IOException ex) { }
+		} finally {
+			try { bos.close(); } catch (IOException ex) { }
+		}
+
+		return ret;
+	}
+
+	/**
+	 * Restore the stored byte-array into an object upon retrieval
+	 * @param bytes The bytes to restore
+	 * @return Returns the object represented by the bytes
+	 */
+	@SuppressWarnings("unchecked")
+	public T fromBytes(byte[] bytes) {
+		ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+		ObjectInput in = null;
+
+		T ret = null;
+		try {
+			in = new ObjectInputStream(bis);
+			ret = (T) in.readObject();
+		} catch (IOException | ClassNotFoundException e) {
+		} finally {
+			try {
+				if (in != null) {
+					in.close();
+				}
+			} catch (IOException ex) { }
+		}
+
+		return ret;
+	}
+
+}

--- a/server/src/main/java/org/elasticsearch/common/path/PathTrieBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/path/PathTrieBuilder.java
@@ -26,14 +26,16 @@ public class PathTrieBuilder<T>{
     public interface Decoder {
         String decode(String value);
     }
-    
+
 	private final Decoder decoder;
 	private final TrieNode<T> root;
-	private T rootValue;
+	private byte[] rootValue;
+	private FSTRepresentation<T> representation;
 
 	public PathTrieBuilder(Decoder decoder){
+		this.representation = new FSTRepresentation<T>();
 		this.decoder = decoder;
-		root = new TrieNode(PathTrie.SEPARATOR, null, PathTrie.WILDCARD);
+		root = new TrieNode<T>(PathTrie.SEPARATOR, null, PathTrie.WILDCARD);
 	}
 
 
@@ -43,8 +45,7 @@ public class PathTrieBuilder<T>{
 	 * immutable as well. Therefore, also create a TrieNodeBuilder
 	 * that builds individual TrieNodes inside the PathTrieBuilder.
 	 * NOTE: Might not be necessary if we can access public inner classes.
-	 */ 
-
+	 */
 
 	//Change the PathTrie so that the constructor takes a TrieNode that we will build up
 
@@ -57,7 +58,7 @@ public class PathTrieBuilder<T>{
             if (rootValue != null) {
                 throw new IllegalArgumentException("Path [/] already has a value [" + rootValue + "]");
             }
-            rootValue = value;
+            rootValue = representation.toBytes(value);
             return;
         }
         int index = 0;
@@ -79,9 +80,11 @@ public class PathTrieBuilder<T>{
         String[] strings = path.split(PathTrie.SEPARATOR);
         if (strings.length == 0) {
             if (rootValue != null) {
-                rootValue = updater.apply(rootValue, value);
+            	T currentValue = representation.fromBytes(rootValue);
+            	T updatedValue = updater.apply(currentValue, value);
+                rootValue = representation.toBytes(updatedValue);
             } else {
-                rootValue = value;
+                rootValue = representation.toBytes(value);
             }
             return;
         }
@@ -95,10 +98,10 @@ public class PathTrieBuilder<T>{
 
 
     /**
-     * Creates a PathTrie object based 
-     * 
+     * Creates a PathTrie object based
+     *
     **/
     public PathTrie<T> createpathTrie(){
-    	return new PathTrie(decoder, root, rootValue);
-    } 
+    	return new PathTrie<T>(decoder, root, rootValue);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/path/TrieNode.java
+++ b/server/src/main/java/org/elasticsearch/common/path/TrieNode.java
@@ -27,7 +27,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
 class TrieNode<T>{
-    
+
     private transient String key;
     private transient T value;
     private boolean isWildcard;
@@ -74,7 +74,7 @@ class TrieNode<T>{
     public synchronized void addChild(TrieNode<T> child) {
         addInnerChild(child.key, child);
     }
-    
+
     /**
      * Add a child
      * @param key the key of the new node
@@ -115,7 +115,7 @@ class TrieNode<T>{
         TrieNode<T> node = children.get(key);
         if (node == null) {
             T nodeValue = index == path.length - 1 ? value : null;
-            node = new TrieNode(token, nodeValue, wildcard);
+            node = new TrieNode<T>(token, nodeValue, wildcard);
             addInnerChild(key, node);
         } else {
             if (isNamedWildcard(token)) {
@@ -158,7 +158,7 @@ class TrieNode<T>{
         TrieNode<T> node = children.get(key);
         if (node == null) {
             T nodeValue = index == path.length - 1 ? value : null;
-            node = new TrieNode(token, nodeValue, wildcard);
+            node = new TrieNode<T>(token, nodeValue, wildcard);
             addInnerChild(key, node);
         } else {
             if (isNamedWildcard(token)) {

--- a/server/src/test/java/org/elasticsearch/common/path/FSTRepresentationTests.java
+++ b/server/src/test/java/org/elasticsearch/common/path/FSTRepresentationTests.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.path;
+
+import org.elasticsearch.rest.RestUtils;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.HashMap;
+
+public class PathTrieTests extends ESTestCase {
+
+	public void testWithString() {
+		FSTRepresentation<String> representation = new FSTRepresentation<String>();
+		String in = "test";
+		byte[] bytes = representation.toBytes(in);
+		String out = representation.fromBytes(bytes);
+
+		// The returned String should contain the same value
+		assertThat(out, equalTo(in));
+		// However, it is not the same object but instead a copy of it
+		assertThat(out, is(not(sameInstance(in))));
+
+		in = null;
+		bytes = representation.toBytes(in);
+		out = representation.fromBytes(bytes);
+
+		// Should work for null-values too
+		assertThat(out, equalTo(null));
+	}
+
+    public void testWithPrimitive() {
+    	FSTRepresentation<Integer> representation = new FSTRepresentation<Integer>();
+    	int in = 42;
+    	byte[] bytes = representation.toBytes(in);
+    	int out = representation.fromBytes(bytes);
+
+    	// The returned integer should contain the same value
+    	assertThat(out, equalTo(in));
+    }
+
+    public void testWithObject() {
+    	FSTRepresentation<HashMap<String, Integer>> representation = new FSTRepresentation<HashMap<String, Integer>>();
+    	HashMap<String, Integer> in = new HashMap<String, Integer>();
+    	in.put("test1", 41);
+    	in.put("test2", 42);
+    	byte[] bytes = representation.toBytes(in);
+    	HashMap<String, Integer> out = representation.fromBytes(bytes);
+
+    	// The returned object should contain the same values
+    	assertThat(out.get("test1"), equalTo(41));
+    	assertThat(out.get("test2"), equalTo(42));
+    }
+}


### PR DESCRIPTION
Elasticsearch wants to use FST with templates.
This has no built-in support, so this PR is a workaround that stores the values as byte-arrays internally and then parses them back to the template type upon retrieval.

This is a requirement in order to fulfill issue #5 