### PR TITLE
fix: Extra example. before OuterClass that shouldn't be there.

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/path/Test.java
+++ b/server/src/main/java/org/elasticsearch/common/path/Test.java
@@ -8,7 +8,7 @@ public class Test {
 		// OuterClass<String> s = new OuterClass<String>("World");
 
 		// Instead we must use the builder
-		example.OuterClass.Builder<String> builder = new OuterClass.Builder<String>();
+		OuterClass.Builder<String> builder = new OuterClass.Builder<String>();
 
 		builder.add("Hello")
 		.add("again")


### PR DESCRIPTION
Some example. was before the OuterClass that shouldn't be there.

Resolves #35 